### PR TITLE
[drg] Fix Wyvern Breaths being paralyzed, Audit Super Jump

### DIFF
--- a/scripts/globals/job_utils/dragoon.lua
+++ b/scripts/globals/job_utils/dragoon.lua
@@ -456,9 +456,13 @@ xi.job_utils.dragoon.useHighJump = function(player, target, ability, action)
 end
 
 xi.job_utils.dragoon.useSuperJump = function(player, target, ability)
-    -- Reduce 99% of total accumulated enmity
-    if target:isMob() then
-        target:lowerEnmity(player, 99)
+    -- http://wiki.ffo.jp/html/3367.html
+    for _, mob in pairs(player:getNotorietyList()) do
+        -- TODO: testing shows max range on this is >50' but stops somewhere above this. Need exact number.
+        if mob:isMob() and mob:checkDistance(player) <= 75.0 then
+            mob:setCE(player, 1)
+            mob:setVE(player, 0)
+        end
     end
 
     ability:setMsg(xi.msg.basic.NONE)
@@ -476,6 +480,38 @@ xi.job_utils.dragoon.useSuperJump = function(player, target, ability)
         wyvern:isEngaged()
     then
         wyvern:useJobAbility(xi.jobAbility.SUPER_CLIMB, wyvern)
+    end
+
+    -- Handle Spirit Surge -50% enmity reduction on super jump to closest party member behind the dragoon
+    if player:hasStatusEffect(xi.effect.SPIRIT_SURGE) then
+        local minDistance = 9999
+        local closestPartyMember = nil
+
+        -- Find the closest party member
+        local party = player:getPartyWithTrusts()
+        for _, member in pairs(party) do
+            local distance = member:checkDistance(player)
+            if
+                member:getID() ~= player:getID() and
+                not member:isDead() and
+                (distance < minDistance or closestPartyMember == nil)
+            then
+                closestPartyMember = member
+                minDistance = distance
+            end
+        end
+
+        -- TODO: verify conditions for how close the dragoon needs to be to the mob, if at all
+        -- It doesn't matter what direction the dragoon is facing http://wiki.ffo.jp/html/3367.html#comment_1
+        if
+            closestPartyMember and
+            closestPartyMember:isBehind(player) and
+            (player:checkDistance(target) < closestPartyMember:checkDistance(target)) -- Verify dragoon is closer than the party member that we want to reduce the enmity of
+        then
+            if target:isMob() then
+                target:lowerEnmity(closestPartyMember, 50)
+            end
+        end
     end
 end
 

--- a/scripts/globals/job_utils/dragoon.lua
+++ b/scripts/globals/job_utils/dragoon.lua
@@ -849,27 +849,27 @@ end
 
 xi.job_utils.dragoon.addWyvernExp = function(player, exp)
     local wyvern   = player:getPet()
-    local prev_exp = wyvern:getLocalVar("wyvern_exp")
-    local levels_gained = wyvern:getLocalVar("wyvern_level_ups")
+    local prevExp = wyvern:getLocalVar("wyvern_exp")
+    local numLevelUps = wyvern:getLocalVar("wyvern_level_ups")
 
-    if prev_exp < 1000 and levels_gained < 5 then
+    if prevExp < 1000 and numLevelUps < 5 then
         -- cap exp at 1000 to prevent wyvern leveling up many times from large exp awards
-        local currentExp = utils.clamp(exp + prev_exp, 0, 1000)
-        local diff = math.floor(currentExp / 200) - levels_gained
+        local currentExp = utils.clamp(exp + prevExp, 0, 1000)
+        local diff = math.floor(currentExp / 200) - numLevelUps
 
         while diff > 0 do
-            -- wyvern levelled up (diff is the number of level ups)
+            -- wyvern leveled up (diff is the number of level ups)
             wyvern:addMod(xi.mod.ACC, 6)
             wyvern:addMod(xi.mod.HPP, 6)
             wyvern:addMod(xi.mod.ATTP, 5)
             wyvern:setHP(wyvern:getMaxHP())
             player:messageBasic(xi.msg.basic.STATUS_INCREASED, 0, 0, wyvern)
-            wyvern:setLocalVar("wyvern_level_ups", levels_gained + 1)
+            wyvern:setLocalVar("wyvern_level_ups", numLevelUps + 1)
             diff = diff - 1
         end
 
-        wyvern:setLocalVar("wyvern_exp", prev_exp + exp)
+        wyvern:setLocalVar("wyvern_exp", prevExp + exp)
     end
 
-    return levels_gained
+    return numLevelUps
 end

--- a/src/map/entities/petentity.cpp
+++ b/src/map/entities/petentity.cpp
@@ -314,7 +314,9 @@ void CPetEntity::OnAbility(CAbilityState& state, action_t& action)
             return;
         }
 
-        if (battleutils::IsParalyzed(this))
+        // Currently, only the Wyvern uses abilities at all as of writing, but their abilities are not instant and are mob abilities.
+        // Abilities are not subject to paralyze if they have non-zero cast time due to this corner case.
+        if (state.GetAbility()->getCastTime() == 0s && battleutils::IsParalyzed(this))
         {
             setActionInterrupted(action, PTarget, MSGBASIC_IS_PARALYZED_2, 0);
             return;


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
These are current retail & era behavior, cherry picked from the LSB

Fixes Wyvern Breaths getting paralyzed
Super Jump + Spirit Surge interaction is implemented
Super Jump now correctly resets enmity to 1 CE 0 VE to all mobs on enmity list within range

## Steps to test these changes


Paralyze verification:
Call wyvern, `!setmod paralyze 100` on wyvern, use Restoring Breath, wyvern should not be paralyzed on use of healing breath
`!addeffect poison` on yourself as drg/rdm, use a weaponskill, your wyvern should use Remove Poison and not be paralyzed

Super jump changes:
get 2 accounts, claim a mob, `!exec target:setCE(player, 30000)`  `!exec target:setVE(player, 30000)`, line up the other account (the DRG) to the mob, get a player behind the DRG (much like a Trick Attack positioning), note `!getenmity`, use call wyvern, spirit surge, then super jump, `!getenmity` on the target should be halved compared to to before the super jump

claim a bunch of mobs with auto attacks for good CE/VE, `!getenmity` on a few, note it's non 1/0 CE/VE, super jump, `!getenmity` should show 1CE/0VE  on all mobs